### PR TITLE
cache: use number of chars across expressions for size limit

### DIFF
--- a/regexp_cache.go
+++ b/regexp_cache.go
@@ -99,11 +99,11 @@ func (rc *regexpCache) Misses() uint64 {
 	return atomic.LoadUint64(&rc.misses)
 }
 
-func (rc *regexpCache) Len() uint64 {
+func (rc *regexpCache) Len() int {
 	rc.mu.RLock()
 	n := len(rc.m)
 	rc.mu.RUnlock()
-	return uint64(n)
+	return n
 }
 
 func (rc *regexpCache) CharsCurrent() int {

--- a/regexp_cache.go
+++ b/regexp_cache.go
@@ -29,13 +29,14 @@ func CompileRegexp(re string) (*regexp.Regexp, error) {
 	return rcv.r, rcv.err
 }
 
+// regexpCacheCharsMax limits the max number of chars stored in regexp cache across all entries.
+//
+// We limit by number of chars since calculating the exact size of each regexp is problematic,
+// while using chars seems like universal approach for short and long regexps.
 const regexpCacheCharsMax = 1e6
 
 var regexpCacheV = func() *regexpCache {
-	rc := &regexpCache{
-		m:          make(map[string]*regexpCacheValue),
-		charsLimit: regexpCacheCharsMax,
-	}
+	rc := newRegexpCache(regexpCacheCharsMax)
 	metrics.NewGauge(`vm_cache_requests_total{type="promql/regexp"}`, func() float64 {
 		return float64(rc.Requests())
 	})
@@ -45,8 +46,11 @@ var regexpCacheV = func() *regexpCache {
 	metrics.NewGauge(`vm_cache_entries{type="promql/regexp"}`, func() float64 {
 		return float64(rc.Len())
 	})
-	metrics.NewGauge(`vm_cache_chars{type="promql/regexp"}`, func() float64 {
-		return float64(rc.chars)
+	metrics.NewGauge(`vm_cache_chars_current{type="promql/regexp"}`, func() float64 {
+		return float64(rc.CharsCurrent())
+	})
+	metrics.NewGauge(`vm_cache_chars_max{type="promql/regexp"}`, func() float64 {
+		return float64(rc.charsLimit)
 	})
 	return rc
 }()
@@ -56,23 +60,35 @@ type regexpCacheValue struct {
 	err error
 }
 
+func (rcv *regexpCacheValue) RegexpLen() int {
+	if r := rcv.r; r != nil {
+		return len(r.String())
+	}
+	return len(rcv.err.Error())
+}
+
 type regexpCache struct {
 	// Move atomic counters to the top of struct for 8-byte alignment on 32-bit arch.
 	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/212
-
 	requests uint64
 	misses   uint64
 
-	// chars stores the total number of characters used in stored regexps.
-	// is used for memory usage estimation
-	chars int
-	// charsLimit limits the max number of chars stored in cache across all entries.
-	// we limit by number of chars since calculating the exact size of each regexp is problematic,
-	// while using chars seems like universal approach for simple and complex expressions.
+	// charsCurrent stores the total number of characters used in stored regexps.
+	// is used for memory usage estimation.
+	charsCurrent int
+
+	// charsLimit is the maximum number of chars the regexpCache can store.
 	charsLimit int
 
 	m  map[string]*regexpCacheValue
 	mu sync.RWMutex
+}
+
+func newRegexpCache(charsLimit int) *regexpCache {
+	return &regexpCache{
+		m:          make(map[string]*regexpCacheValue),
+		charsLimit: charsLimit,
+	}
 }
 
 func (rc *regexpCache) Requests() uint64 {
@@ -90,6 +106,13 @@ func (rc *regexpCache) Len() uint64 {
 	return uint64(n)
 }
 
+func (rc *regexpCache) CharsCurrent() int {
+	rc.mu.RLock()
+	n := rc.charsCurrent
+	rc.mu.RUnlock()
+	return int(n)
+}
+
 func (rc *regexpCache) Get(regexp string) *regexpCacheValue {
 	atomic.AddUint64(&rc.requests, 1)
 
@@ -105,15 +128,15 @@ func (rc *regexpCache) Get(regexp string) *regexpCacheValue {
 
 func (rc *regexpCache) Put(regexp string, rcv *regexpCacheValue) {
 	rc.mu.Lock()
-	if rc.chars-rc.charsLimit > 0 {
+	if rc.charsCurrent > rc.charsLimit {
 		// Remove items accounting for 10% chars from the cache.
 		overflow := int(float64(rc.charsLimit) * 0.1)
-		for k := range rc.m {
+		for k, v := range rc.m {
 			delete(rc.m, k)
 
-			size := len(regexp)
+			size := len(k) + v.RegexpLen()
 			overflow -= size
-			rc.chars -= size
+			rc.charsCurrent -= size
 
 			if overflow <= 0 {
 				break
@@ -121,6 +144,6 @@ func (rc *regexpCache) Put(regexp string, rcv *regexpCacheValue) {
 		}
 	}
 	rc.m[regexp] = rcv
-	rc.chars += len(regexp)
+	rc.charsCurrent += len(regexp) + rcv.RegexpLen()
 	rc.mu.Unlock()
 }

--- a/regexp_cache_test.go
+++ b/regexp_cache_test.go
@@ -1,26 +1,54 @@
 package metricsql
 
-import "testing"
+import (
+	"regexp"
+	"testing"
+)
 
-func TestRegexpCache_Put(t *testing.T) {
-	fn := func(limit int, put []string, expChars int) {
+func TestRegexpCache(t *testing.T) {
+	fn := func(limit int, regexps []string, expectedEntries, expectedChars int) {
 		t.Helper()
-		rc := &regexpCache{
-			m:          make(map[string]*regexpCacheValue),
-			charsLimit: limit,
+		rc := newRegexpCache(limit)
+		for _, re := range regexps {
+			r, err := regexp.Compile(re)
+			rcv := &regexpCacheValue{
+				r:   r,
+				err: err,
+			}
+			rc.Put(re, rcv)
+			rcv1 := rc.Get(re)
+			if rcv1 != rcv {
+				t.Fatalf("unexpected result for regexp %q; got\n%v\nwant\n%v", re, rcv1, rcv)
+			}
 		}
-		for _, p := range put {
-			rc.Put(p, nil)
+		if requests := rc.Requests(); requests != uint64(len(regexps)) {
+			t.Fatalf("unexpected number of requests; got %d; want %d", requests, len(regexps))
 		}
-		if rc.chars != expChars {
-			t.Errorf("expected cache to contain %d chars; got %d", expChars, rc.chars)
+		if misses := rc.Misses(); misses != 0 {
+			t.Fatalf("unexpected number of misses; got %d; want 0", misses)
+		}
+		rcv := rc.Get("non-existing-regexp")
+		if rcv != nil {
+			t.Fatalf("expecting nil entry; got %v", rcv)
+		}
+		if misses := rc.Misses(); misses != 1 {
+			t.Fatalf("unexpected number of misses; got %d; want 1", misses)
+		}
+		if entries := rc.Len(); entries != uint64(expectedEntries) {
+			t.Fatalf("unexpected number of entries; got %d; want %d", entries, expectedEntries)
+		}
+		if chars := rc.CharsCurrent(); chars != expectedChars {
+			t.Fatalf("unexpected charsCurrent; got %d; want %d", chars, expectedChars)
 		}
 	}
 
-	fn(10, []string{"a", "b", "c"}, 3)
-	fn(2, []string{"a", "b", "c"}, 3) // overflow by 1 entry is allowed
-	fn(2, []string{"a", "b", "c", "d"}, 3)
-	fn(1, []string{"a", "b", "c"}, 2)
-	fn(2, []string{"abcd", "efgh", "ijkl"}, 4) // overflow by 1 entry is allowed
-	fn(4, []string{"123", "456", "789"}, 6)    // overflow by 1 entry is allowed
+	fn(10, []string{"a", "b", "c"}, 3, 6)
+	fn(2, []string{"a", "b", "c"}, 2, 4) // overflow by 1 entry is allowed
+	fn(2, []string{"a", "b", "c", "d"}, 2, 4)
+	fn(1, []string{"a", "b", "c"}, 1, 2)
+	fn(2, []string{"abcd", "efgh", "ijkl"}, 1, 8)   // overflow by 1 entry is allowed
+	fn(5, []string{"123", "fd{456", "789"}, 1, 6)   // overflow by 1 entry is allowed
+	fn(18, []string{"123", "fd{456", "789"}, 3, 24) // overflow by 1 entry is allowed
+	fn(24, []string{"123", "fd{456", "789"}, 3, 24)
+	fn(30, []string{"123", "fd{456", "789"}, 3, 24)
 }

--- a/regexp_cache_test.go
+++ b/regexp_cache_test.go
@@ -1,0 +1,26 @@
+package metricsql
+
+import "testing"
+
+func TestRegexpCache_Put(t *testing.T) {
+	fn := func(limit int, put []string, expChars int) {
+		t.Helper()
+		rc := &regexpCache{
+			m:          make(map[string]*regexpCacheValue),
+			charsLimit: limit,
+		}
+		for _, p := range put {
+			rc.Put(p, nil)
+		}
+		if rc.chars != expChars {
+			t.Errorf("expected cache to contain %d chars; got %d", expChars, rc.chars)
+		}
+	}
+
+	fn(10, []string{"a", "b", "c"}, 3)
+	fn(2, []string{"a", "b", "c"}, 3) // overflow by 1 entry is allowed
+	fn(2, []string{"a", "b", "c", "d"}, 3)
+	fn(1, []string{"a", "b", "c"}, 2)
+	fn(2, []string{"abcd", "efgh", "ijkl"}, 4) // overflow by 1 entry is allowed
+	fn(4, []string{"123", "456", "789"}, 6)    // overflow by 1 entry is allowed
+}


### PR DESCRIPTION
Current implementation limits the cache size by number of entries
and is equal to 10k entries. However, the size of each entry may
significantly vary depending on expression complexity. This could
result into unexpected memory usage by this lib for cases when
rich and complex expressions are used.

On the other hand, size of the expression supposed to correlate
with its string representation. In this change, we switch from
limiting the cache size by entries to limiting by total number
of chars across all stored expressions. This supposed to put more
strict boundaries on memory usage for scenarios where simple and
complex regexp are used.