### PR TITLE
optimizer: do not push down label filters from aggregation function args if arg is aggr function

### DIFF
--- a/optimizer.go
+++ b/optimizer.go
@@ -379,6 +379,14 @@ func getAggrArgIdxForOptimization(funcName string, args []Expr) int {
 	case "quantiles":
 		return len(args) - 1
 	default:
+		if len(args) > 1 {
+			for _, e := range args {
+				if _, ok := e.(*AggrFuncExpr); ok {
+					return -1
+				}
+			}
+		}
+
 		return 0
 	}
 }

--- a/optimizer_test.go
+++ b/optimizer_test.go
@@ -220,6 +220,22 @@ func TestOptimize(t *testing.T) {
 	f(`topk(a, foo) without (x,y) + bar{baz="a"}`, `topk(a, foo{baz="a"}) without(x,y) + bar{baz="a"}`)
 	f(`a{b="c"} + quantiles("foo", 0.1, 0.2, bar{x="y"}) by (b, x, y)`, `a{b="c",x="y"} + quantiles("foo", 0.1, 0.2, bar{b="c",x="y"}) by(b,x,y)`)
 	f(`count_values("foo", bar{baz="a"}) by (bar,b) + a{b="c"}`, `count_values("foo", bar{baz="a"}) by(bar,b) + a{b="c"}`)
+	f(
+		`sum(
+				avg(foo{bar="one"}) by (bar),
+				avg(foo{bar="two"}[1i]) by (bar)
+			) by(bar) 
+			+ avg(foo{bar="three"}) by(bar)`,
+		`sum(avg(foo{bar="one"}) by(bar), avg(foo{bar="two"}[1i]) by(bar)) by(bar) + avg(foo{bar="three"}) by(bar)`,
+	)
+	f(
+		`sum(
+				foo{bar="one"},
+				avg(foo{bar="two"}[1i]) by (bar)
+			) by(bar) 
+			+ avg(foo{bar="three"}) by(bar)`,
+		`sum(foo{bar="one"}, avg(foo{bar="two"}[1i]) by(bar)) by(bar) + avg(foo{bar="three"}) by(bar)`,
+	)
 
 	// transform funcs
 	f(`round(foo{bar="baz"}) + sqrt(a{z=~"c"})`, `round(foo{bar="baz",z=~"c"}) + sqrt(a{bar="baz",z=~"c"})`)


### PR DESCRIPTION
In case aggregation function received one or more aggregation functions pushing down label filters can be dangerous and lead to empty results.

This change disables optimizer in case any of aggregation function args is also an aggregation function.

See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5604