### PR TITLE
strings extraction: extract values with custom UTF encoding from strings

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1166,6 +1166,9 @@ func extractStringValue(token string) (string, error) {
 		token = strings.Replace(token, `"`, `\"`, -1)
 		token = `"` + token + `"`
 	}
+	if hasUTFEscapedSymbols(token) {
+		token = unescapeUTFSymbols(token)
+	}
 	s, err := strconv.Unquote(token)
 	if err != nil {
 		return "", fmt.Errorf(`cannot parse string literal %q: %s`, token, err)

--- a/parser_test.go
+++ b/parser_test.go
@@ -181,6 +181,12 @@ func TestParseSuccess(t *testing.T) {
 	another(`\温\度{\房\间="水电费"}[5m] offset 10m`, `温度{房间="水电费"}[5m] offset 10m`)
 	same(`sum(fo\|o) by(b\|a,x)`)
 	another(`sum(x) by (b\x7Ca)`, `sum(x) by(b\|a)`)
+	another(`fo\xF3`, `foó`)
+	another(`fo\u00F3`, `foó`)
+	another(`{__name__="fo\xF3"}`, `foó`)
+	another(`{__name__="fo\xF3"}`, `foó`)
+	another(`"\n\tfo\xF3"`, `"\n\tfoó"`)
+	another(`温度{房间="水电费\xF3"}[5m] offset 10m`, `温度{房间="水电费ó"}[5m] offset 10m`)
 
 	// Duplicate filters
 	same(`foo{a="b",a="c",b="d"}`)


### PR DESCRIPTION
Previously, only quoted values of UTF escaped sequences were converted into UTF runes due to Go strings semantics. Also, it would not decode values with non-standard Go escaping.

This change adds additional decoding logic to always convert escape sequence into character.

See also: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5519