### PR TITLE
parser: removes misleading panic from durationExpr AppendString

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1578,9 +1578,6 @@ func (de *DurationExpr) AppendString(dst []byte) []byte {
 	if de == nil {
 		return dst
 	}
-	if de.needsParsing {
-		panic(fmt.Errorf("BUG: duration %q must be already parsed with expandWithExpr()", de.s))
-	}
 	return append(dst, de.s...)
 }
 

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -43,6 +43,7 @@ func TestPrettifyOkParseError(t *testing.T) {
 	}
 
 	f(`sum(rate{a="b"}[BAZ])`, `cannot expand WITH expressions: cannot parse window for rate{a="b"}: cannot find WITH template for "BAZ"`)
+	f(`WITH (ru(freev, maxv) = bad_func1(maxv - bad_func_2(freev, 0), 0) / clamp_min(maxv, 0) * 100) ru(1,2)`, `unsupported function "bad_func_2"`)
 }
 
 func TestPrettifySuccess(t *testing.T) {

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -21,6 +21,30 @@ func TestPrettifyError(t *testing.T) {
 	f(`invalid query`)
 }
 
+func TestPrettifyOkParseError(t *testing.T) {
+	f := func(s string, wantErr string) {
+		t.Helper()
+
+		// check prettify ok
+		// it should not check query for semantic errors
+		result, err := Prettify(s)
+		if err != nil {
+			t.Fatalf("unexpected error when prettifying: %q: %s", s, err)
+		}
+
+		// Verify that the prettified result is failed to parse due to semantic error
+		_, err = Parse(result)
+		if err == nil {
+			t.Fatalf("expecting non-nil error")
+		}
+		if err.Error() != wantErr {
+			t.Fatalf("unexpected error string:\ngot:\n%q\nwant:\n%q", err, wantErr)
+		}
+	}
+
+	f(`sum(rate{a="b"}[BAZ])`, `cannot expand WITH expressions: cannot parse window for rate{a="b"}: cannot find WITH template for "BAZ"`)
+}
+
 func TestPrettifySuccess(t *testing.T) {
 	another := func(s, resultExpected string) {
 		t.Helper()
@@ -189,4 +213,6 @@ x + sum(y)`)
   x = a{b="c"} + WITH (q = we{rt="z"}) q,
 )
 (abc / x) + WITH (rt = 234 + 234) (2 * rt) + poasdfklkjlkjfdsfjklfdfdsfdsfddfsfd`)
+	another(`WITH(BAR=1m,x=sum(rate({a="b"}[BAR]))) x`, `WITH (BAR = 1m,x = sum(rate({a="b"}[BAR]))) x`)
+	same(`WITH (x = sum(rate({a="b"}[1m]))) x`)
 }


### PR DESCRIPTION
This function shouldn't check for parsing logic. It must return original string to the caller.

It resolves the case for Prettify api calls.
Prettify should check expression syntax without semantic checks. It may return symantically incorrect expression, but with prettified structure.

https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6736