### PR TITLE
fix: pow() return nan if left expr is nan

### DIFF
--- a/binaryop/funcs.go
+++ b/binaryop/funcs.go
@@ -76,6 +76,9 @@ func Mod(left, right float64) float64 {
 
 // Pow returns pow(left, right)
 func Pow(left, right float64) float64 {
+	if math.IsNaN(left) {
+		return nan
+	}
 	return math.Pow(left, right)
 }
 

--- a/binaryop/funcs.go
+++ b/binaryop/funcs.go
@@ -74,8 +74,10 @@ func Mod(left, right float64) float64 {
 	return math.Mod(left, right)
 }
 
-// Pow returns pow(left, right)
+// Pow returns pow(left, right) if left is not NaN. Otherwise NaN is returned.
 func Pow(left, right float64) float64 {
+	// special case for NaN^any
+	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7359
 	if math.IsNaN(left) {
 		return nan
 	}


### PR DESCRIPTION
Fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7359

Currently, the `pow(left, right expr)` function always returns `1` when `right` is `0`. This behavior is valid according to the documentation for `Pow` func in Go [here](https://go.dev/src/math/pow.go).

In a time series scenario, `NaN ^ any` should result in `NaN`, which is also consistent with Prometheus's implementation. See test [here](https://play.grafana.org/explore?schemaVersion=1&panes=%7B%22crr%22%3A%7B%22datasource%22%3A%22grafanacloud-demoinfra-prom%22%2C%22queries%22%3A%5B%7B%22refId%22%3A%22A%22%2C%22expr%22%3A%22%28hour%28%29+%3D%3D+12%29+%5E+0%22%2C%22range%22%3Atrue%2C%22instant%22%3Atrue%2C%22datasource%22%3A%7B%22type%22%3A%22prometheus%22%2C%22uid%22%3A%22grafanacloud-demoinfra-prom%22%7D%2C%22editorMode%22%3A%22code%22%2C%22legendFormat%22%3A%22__auto%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-7d%22%2C%22to%22%3A%22now%22%7D%7D%7D&orgId=1).