### PR TITLE
bug: fix push down filter for `ifnot` expression

### DIFF
--- a/optimizer.go
+++ b/optimizer.go
@@ -149,6 +149,10 @@ func getCommonLabelFilters(e Expr) []LabelFilter {
 			// {f1} unless on(f1, f2) {f2} -> {f1}
 			// {f1} unless on(f3) {f2} -> {}
 			return TrimFiltersByGroupModifier(lfsLeft, t)
+		case "ifnot":
+			// remove right from left, so filter in left can be pushed down to right.
+			// {f1} ifnot `any` -> {f1}
+			return TrimFiltersByGroupModifier(lfsLeft, t)
 		default:
 			switch strings.ToLower(t.JoinModifier.Op) {
 			case "group_left":

--- a/optimizer_test.go
+++ b/optimizer_test.go
@@ -191,6 +191,7 @@ func TestOptimize(t *testing.T) {
 	f(`a + on(x) group_left(*) (prefix{x="a"})`, `a{x="a"} + on(x) group_left(*) (prefix{x="a"})`)
 	f(`a + on(x) group_right(*) prefix "foo_" b{x="a"}`, `a{x="a"} + on(x) group_right(*) prefix "foo_" b{x="a"}`)
 	f(`a{x="a"} + on(x) group_right(*) prefix "foo_" prefix`, `a{x="a"} + on(x) group_right(*) prefix "foo_" (prefix{x="a"})`)
+	f(`foo{bar="a"} ifnot foo{bar="b"}`, `foo{bar="a"} ifnot foo{bar="a",bar="b"}`)
 
 	// specially handled binary expressions
 	f(`foo{a="b"} or bar{x="y"}`, `foo{a="b"} or bar{x="y"}`)


### PR DESCRIPTION
## Changes

Previously, `getCommonLabelFilters` returns labels in common for both `left` and `right`. So `pushdownBinaryOpFiltersInplace` attach common filter to both `left` and `right` as well.

For expression `foo{bar="a"} ifnot foo{bar="b"}`, it will became `foo{bar="a", bar="b"} ifnot foo{bar="a", bar="b"}` thus empty result.

This pull request add special logic for `ifnot` in `getCommonLabelFilters`, which returns filter in `left`. So after `pushdownBinaryOpFiltersInplace`, the expression will become `leftFilter ifnot (left+rightFilters)`. For previous example it becomes `foo{bar="a"} ifnot foo{bar="a", bar="b"}`.