### PR TITLE
parser: return an error if duration is out of expected bounds instead of panic

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1663,7 +1663,10 @@ func (de *DurationExpr) AppendString(dst []byte) []byte {
 //
 // Error is returned if the duration is negative.
 func (de *DurationExpr) NonNegativeDuration(step int64) (int64, error) {
-	d := de.Duration(step)
+	d, err := de.Duration(step)
+	if err != nil {
+		return 0, err
+	}
 	if d < 0 {
 		return 0, fmt.Errorf("unexpected negative duration %dms", d)
 	}
@@ -1671,18 +1674,18 @@ func (de *DurationExpr) NonNegativeDuration(step int64) (int64, error) {
 }
 
 // Duration returns the duration from de in milliseconds.
-func (de *DurationExpr) Duration(step int64) int64 {
+func (de *DurationExpr) Duration(step int64) (int64, error) {
 	if de == nil {
-		return 0
+		return 0, nil
 	}
 	if de.needsParsing {
 		panic(fmt.Errorf("BUG: duration %q must be already parsed", de.s))
 	}
 	d, err := DurationValue(de.s, step)
 	if err != nil {
-		panic(fmt.Errorf("BUG: cannot parse duration %q: %s", de.s, err))
+		return 0, fmt.Errorf("cannot parse duration %q: %w", de.s, err)
 	}
-	return d
+	return d, nil
 }
 
 // parseIdentExpr parses expressions starting with `ident` token.

--- a/parser_test.go
+++ b/parser_test.go
@@ -1008,3 +1008,30 @@ func TestParseError(t *testing.T) {
 	f(`with (x={a="b" or c="d"}) {x,d="e"}`)
 	f(`with (x={a="b" or c="d"}) {x,d="e" or z="c"}`)
 }
+
+func TestParseDuration(t *testing.T) {
+	s := func(v string, step, expected int64) {
+		de := DurationExpr{s: v}
+		result, err := de.NonNegativeDuration(step)
+		if err != nil {
+			t.Fatalf("unexpected error: %s", err)
+		}
+		if result != expected {
+			t.Fatalf("unexpected result; got %d, expected %d", result, expected)
+		}
+	}
+
+	f := func(v string, step int64) {
+		de := DurationExpr{s: v}
+		_, err := de.NonNegativeDuration(step)
+		if err == nil {
+			t.Fatalf("expecting error, got nil")
+		}
+	}
+
+	s("1i", 10, 10)
+	s("10s", 300, 10*1000)
+
+	// too large resulting value
+	f("99999999999999999999i", 10)
+}


### PR DESCRIPTION
See: https://github.com/VictoriaMetrics/VictoriaMetrics/issues/8447
