### PR TITLE
Fix multiple or filters with non-identical __name__ (#50)

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -833,12 +833,16 @@ func expandWithExpr(was []*withArgExpr, e Expr) (Expr, error) {
 			// Already expanded.
 			return t, nil
 		}
-		metricName := ""
 		{
 			var me MetricExpr
 			// Populate me.LabelFilterss
 
+			// Find out if all or-subclauses that specify a metric name agree on one
+			// NB: cannot use a guard value because metric names can be any string
+			commonMetricName := ""
+			haveCommonMetric := true
 			for _, lfes := range t.labelFilterss {
+				localMetricName := ""
 				var lfsNew []LabelFilter
 				for _, lfe := range lfes {
 					if lfe.Value == nil {
@@ -849,15 +853,11 @@ func expandWithExpr(was []*withArgExpr, e Expr) (Expr, error) {
 							// This means label name set and starts and ends with quotes
 							// but value is nil
 							if lfe.IsPossibleMetricName {
-								if metricName == "" {
-									metricName = lfe.Label
-									continue
-								} else {
-									if metricName != lfe.Label {
-										return nil, fmt.Errorf("parse error: metric name must not be set twice: %q or %q", metricName, lfe.Label)
-									}
-									continue
+								var err error
+								if lfsNew, localMetricName, err = checkAndPrependMetricNameFilter(lfsNew, localMetricName, lfe.Label); err != nil {
+									return nil, err
 								}
+								continue
 							}
 							return nil, fmt.Errorf("cannot find WITH template for %q inside %q", lfe.Label, t.AppendString(nil))
 						}
@@ -898,33 +898,42 @@ func expandWithExpr(was []*withArgExpr, e Expr) (Expr, error) {
 						return nil, err
 					}
 					if lf.isMetricNameFilter() {
-						if metricName != "" && metricName != lf.Value {
-							return nil, fmt.Errorf("parse error: metric name must not be set twice: %q or %q", metricName, lf.Value)
+						if lfsNew, localMetricName, err = checkAndPrependMetricNameFilter(lfsNew, localMetricName, lf.Value); err != nil {
+							return nil, err
 						}
-						metricName = lf.Value
-						continue
+					} else {
+						lfsNew = append(lfsNew, *lf)
 					}
-					lfsNew = append(lfsNew, *lf)
+				}
+				if haveCommonMetric && localMetricName != "" {
+					if commonMetricName == "" {
+						commonMetricName = localMetricName
+					} else if commonMetricName != localMetricName {
+						haveCommonMetric = false
+					}
 				}
 				lfsNew = removeDuplicateLabelFilters(lfsNew)
 				me.LabelFilterss = append(me.LabelFilterss, lfsNew)
 			}
-			// Prepend metric name to latest
-			if metricName != "" {
-				lfesCount := len(t.labelFilterss)
-				for i := 1; i <= lfesCount; i++ {
-					lfsLastIndex := len(me.LabelFilterss) - i
-					var lfsNew []LabelFilter
-					var lfNew LabelFilter
-					lfNew.Label = "__name__"
-					lfNew.Value = metricName
-					lfsNew = append(lfsNew, lfNew)
-					lfsNew = append(lfsNew, me.LabelFilterss[lfsLastIndex]...)
-					me.LabelFilterss[lfsLastIndex] = lfsNew
+			// If all or-subclauses that specify a metric name agree on one, prepend it to clauses
+			// where __name__ is missing entirely (incuding regexes and negatives)
+			if haveCommonMetric && commonMetricName != "" {
+				for i, lfs := range me.LabelFilterss {
+					haveNameClause := false
+					for _, lf := range lfs {
+						if lf.Label == "__name__" {
+							haveNameClause = true
+							break
+						}
+					}
+					if !haveNameClause {
+						me.LabelFilterss[i] = prependMetricNameFilter(lfs, commonMetricName)
+					}
 				}
 			}
 			t = &me
 		}
+		metricName := t.getMetricName()
 		if metricName == "" {
 			return t, nil
 		}
@@ -993,6 +1002,20 @@ func expandWithExpr(was []*withArgExpr, e Expr) (Expr, error) {
 	default:
 		return e, nil
 	}
+}
+
+func checkAndPrependMetricNameFilter(lfs []LabelFilter, metricName string, newMetricName string) ([]LabelFilter, string, error) {
+	if metricName != "" && metricName != newMetricName {
+		return nil, "", fmt.Errorf("parse error: metric name must not be set twice: %q or %q", metricName, newMetricName)
+	}
+	return prependMetricNameFilter(lfs, newMetricName), newMetricName, nil
+}
+
+func prependMetricNameFilter(lfs []LabelFilter, metricName string) []LabelFilter {
+	var lf LabelFilter
+	lf.Label = "__name__"
+	lf.Value = metricName
+	return append([]LabelFilter{lf}, lfs...)
 }
 
 func expandWithArgs(was []*withArgExpr, args []Expr) ([]Expr, error) {

--- a/parser_test.go
+++ b/parser_test.go
@@ -129,6 +129,10 @@ func TestParseSuccess(t *testing.T) {
 	another(`{__name__="a",bar="baz" or __name__="a" or __name__="a"}`, `a{bar="baz"}`)
 	another(`{__name__="a",bar="baz" or __name__="a",bar="abc"}`, `a{bar="baz" or bar="abc"}`)
 	another(`{__name__="a" or __name__="a",bar="abc",x!="y"}`, `a{bar="abc",x!="y"}`)
+	another(`{__name__="metric",a="1" or __name__="metric",b="2"}`, `metric{a="1" or b="2"}`)
+	another(`{"foo",a="1" or "bar",b="2"}`, `{__name__="foo",a="1" or __name__="bar",b="2"}`)
+	same(`{__name__="foo",a="1" or __name__="bar",b="2"}`)
+	same(`{__name__="foo",a="1" or __name__=~"bar",b="2"}`)
 
 	// @ modifier
 	// See https://prometheus.io/docs/prometheus/latest/querying/basics/#modifier


### PR DESCRIPTION
https://github.com/VictoriaMetrics/metricsql/pull/43 added support for Prometheus 3.0 quoted metric names, but inadvertently broke time series selectors with [multiple or filters](https://docs.victoriametrics.com/victoriametrics/keyconcepts/#filtering-by-multiple-or-filters) when `or` groups contain explicit non-identical `__name__` clauses (#50). This PR fixes the issue.