### PR TITLE
parser: allow utf-8 quoted label names at indetList

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -1247,6 +1247,11 @@ func (p *parser) parseIdentList(allowStar bool) ([]string, error) {
 			}
 			return idents, nil
 		}
+		if isQuotedString(p.lex.Token) {
+			// indent could be quoted according to prometheus utf-8 encoding
+			// https://github.com/prometheus/proposals/blob/main/proposals/2023-08-21-utf8.md
+			p.lex.Token = p.lex.Token[1 : len(p.lex.Token)-1]
+		}
 		if !isIdentPrefix(p.lex.Token) {
 			return nil, fmt.Errorf(`identList: unexpected token %q; want "ident"`, p.lex.Token)
 		}

--- a/parser_test.go
+++ b/parser_test.go
@@ -448,6 +448,8 @@ func TestParseSuccess(t *testing.T) {
 	same(`avg(x) limit 10`)
 	same(`avg(x) without(z,b) limit 1`)
 	another(`avg by(x) (z) limit 20`, `avg(z) by(x) limit 20`)
+	// utf-8 quoted label names
+	another(`sum({"metric name","label"="value"}) by ("cluster!one",instance)`, `sum(metric\ name{label="value"}) by(cluster\!one,instance)`)
 
 	// All the above
 	another(`Sum(timestamp(M) * M{X=""}[5m] Offset 7m - 123, 35) BY (X, y) * LAG("Test")`,


### PR DESCRIPTION
It makes metricsql compatible with prometheus 3.0 utf-8 query requests.

https://github.com/prometheus/proposals/blob/main/proposals/2023-08-21-utf8.md

This is follow-up commit for e0dbf51c37191e80713e838fe79e742b75448887

Related issue:
https://github.com/VictoriaMetrics/VictoriaMetrics/issues/7703