### PR TITLE
utils: fix timestamp function validation in IsLikelyInvalid

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -83,6 +83,17 @@ func IsLikelyInvalid(e Expr) bool {
 		if !ok {
 			return
 		}
+		if fe.Name == `timestamp` {
+			// In Prometheus, timestamp is defined as a transform function on instant vectors,
+			// but its behavior is closer to a rollup since it returns raw sample timestamps.
+			// VictoriaMetrics explicitly defines timestamp as a rollup function.
+			// To remain consistent with Prometheus, IsLikelyInvalid does not treat timestamp
+			// as an implicit conversion even when applied to non-metric expressions, like timestamp(sum(foo)).
+			//
+			// See more in https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9527#issuecomment-3191439447
+			return
+		}
+
 		idx := GetRollupArgIdx(fe)
 		if idx < 0 || idx >= len(fe.Args) {
 			return

--- a/utils_test.go
+++ b/utils_test.go
@@ -85,6 +85,7 @@ func TestIsLikelyInvalid(t *testing.T) {
 
 	// This should be OK, since it is easy to reason about
 	f(`rate(foo)`, false)
+	f(`timestamp(foo)`, false)
 	f(`foo[5m]`, false)
 	f(`1 + foo[5m]`, false)
 
@@ -103,6 +104,7 @@ func TestIsLikelyInvalid(t *testing.T) {
 	// This is OK, since it is supported by Prometheus
 	f(`rate(foo{bar=~"baz"}[5m:1s])`, false)
 	f(`rate(foo{bar=~"baz"}[5m:1s] offset 1h)`, false)
+	f(`timestamp(sum(foo))`, false)
 
 	f(`sum(foo)`, false)
 	f(`sum(rate(foo))`, false)


### PR DESCRIPTION
This aligns timestamp behavior with Prometheus semantics, where it's treated as a transform function rather than a rollup, allowing usage with non-metric expressions like timestamp(sum(foo)).

See more in https://github.com/VictoriaMetrics/VictoriaMetrics/issues/9527#issuecomment-3191439447