### PR TITLE
support variables, that are passed instead of numbers

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -122,13 +122,12 @@ again:
 		}
 		goto tokenFoundLabel
 	}
-	if strings.HasPrefix(s, "$__interval") {
-		lex.sTail = s[len("$__interval"):]
-		return "$__interval", nil
-	}
-	if strings.HasPrefix(s, "$__rate_interval") {
-		lex.sTail = s[len("$__rate_interval"):]
-		return "$__interval", nil
+	if isVariable(s) {
+		token, err = scanVariable(s)
+		if err != nil {
+			return "", err
+		}
+		goto tokenFoundLabel
 	}
 	return "", fmt.Errorf("cannot recognize %q", s)
 
@@ -299,6 +298,43 @@ func scanPositiveNumber(s string) (string, error) {
 		return "", fmt.Errorf("missing exponent part in %q", s)
 	}
 	return s[:j], nil
+}
+
+func isVariable(s string) bool {
+	return len(s) > 1 && s[0] == '$'
+}
+
+func isVariableChar(c byte) bool {
+	return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_'
+}
+
+func scanVariable(s string) (string, error) {
+	if len(s) < 2 {
+		return "", fmt.Errorf("too small string for a variable %q", s)
+	}
+	i := 1
+	hasBraces := s[i] == '{'
+	if hasBraces {
+		i++
+	}
+	for i < len(s) {
+		if hasBraces {
+			if s[i] == '}' {
+				i++
+				break
+			}
+			if !isVariableChar(s[i]) {
+				return "", fmt.Errorf("not allowed symbol in variable %q", s)
+			}
+		} else if !isVariableChar(s[i]) {
+			break
+		}
+		i++
+	}
+	if hasBraces && i <= 3 || i <= 2 {
+		return "", fmt.Errorf("impossible variable name %q", s)
+	}
+	return s[:i], nil
 }
 
 func scanNumMultiplier(s string) int {
@@ -537,7 +573,7 @@ func scanSpecialIntegerPrefix(s string) (skipChars int, isHex bool) {
 }
 
 func isPositiveDuration(s string) bool {
-	if s == "$__interval" {
+	if s == "$__interval" || s == "$__rate_interval" || s == "$__range" {
 		return true
 	}
 	n := scanDuration(s)
@@ -613,7 +649,7 @@ func DurationValue(s string, step int64) (int64, error) {
 }
 
 func parseSingleDuration(s string, step int64) (float64, error) {
-	if s == "$__interval" {
+	if s == "$__interval" || s == "$__rate_interval" || s == "$__range" {
 		return float64(step), nil
 	}
 
@@ -679,8 +715,8 @@ func scanSingleDuration(s string, canBeNegative bool) int {
 	if s[0] == '-' && canBeNegative {
 		i++
 	}
-	if s[i:] == "$__interval" {
-		return i + len("$__interval")
+	if s[i:] == "$__interval" || s[i:] == "$__rate_interval" || s[i:] == "$__range" {
+		return i + len(s[i:])
 	}
 	for i < len(s) && isDecimalChar(s[i]) {
 		i++

--- a/lexer_test.go
+++ b/lexer_test.go
@@ -98,6 +98,33 @@ func TestScanPositiveNumberFailure(t *testing.T) {
 	f("12.34e-")
 }
 
+func TestScanVariableSuccess(t *testing.T) {
+	f := func(s, vsExpected string) {
+		t.Helper()
+		vs, err := scanVariable(s)
+		if err != nil {
+			t.Fatalf("unexpected error in scanVariable(%q): %s", s, err)
+		}
+		if vs != vsExpected {
+			t.Fatalf("unexpected variable scanned from %q; got %q; want %q", s, vs, vsExpected)
+		}
+	}
+	f("$__rate_interval", "$__rate_interval")
+	f("${foobar},test", "${foobar}")
+}
+
+func TestScanVariableFailure(t *testing.T) {
+	f := func(s string) {
+		t.Helper()
+		vs, err := scanVariable(s)
+		if err == nil {
+			t.Fatalf("expecting non-nil error in scanVariable(%q); got result %q", s, vs)
+		}
+	}
+	f("")
+	f("${foobar,")
+}
+
 func TestParsePositiveNumberSuccess(t *testing.T) {
 	f := func(s string, vExpected float64) {
 		t.Helper()

--- a/prettifier.go
+++ b/prettifier.go
@@ -2,7 +2,12 @@ package metricsql
 
 // Prettify returns prettified representation of MetricsQL query q.
 func Prettify(q string) (string, error) {
-	e, err := parseInternal(q)
+	return PrettifyWithVars(q, false)
+}
+
+// PrettifyWithVars returns prettified representation of MetricsQL query q and keeps expression variables depending on keepVars value.
+func PrettifyWithVars(q string, keepVars bool) (string, error) {
+	e, err := parseInternal(q, keepVars)
 	if err != nil {
 		return "", err
 	}

--- a/transform.go
+++ b/transform.go
@@ -60,6 +60,7 @@ var transformFuncs = map[string]bool{
 	"label_transform":            true,
 	"label_uppercase":            true,
 	"label_value":                true,
+	"label_values":               true,
 	"labels_equal":               true,
 	"limit_offset":               true,
 	"ln":                         true,


### PR DESCRIPTION
- support variables, that are passed instead of numbers
- add ParseWithVars, that preserves variables in expressions
- add label_values function support to parse grafana queries

using library to properly modify metricsql expressions imported rules and dashboards [here](https://github.com/VictoriaMetrics/helm-charts/blob/master/hack/rules-and-dashboards/main.go). while parsing metricsql expression in grafana dashboards it fails when:
- unquoted variable is used as a function argument: `histogram_quantile($quantile, sum(rate(http_request_duration_seconds_bucket[5m])) by (le))`
- parsing expression, which contains grafana specific `label_values` function