### PR TITLE
metricsql: add function histogram_fraction()

### DIFF
--- a/optimizer.go
+++ b/optimizer.go
@@ -695,7 +695,7 @@ func getTransformArgIdxForOptimization(funcName string, args []Expr) int {
 		return -1
 	case "end", "now", "pi", "ru", "start", "step", "time":
 		return -1
-	case "limit_offset":
+	case "limit_offset", "histogram_fraction":
 		return 2
 	case "buckets_limit", "histogram_quantile", "histogram_share", "range_quantile",
 		"range_trim_outliers", "range_trim_spikes", "range_trim_zscore":

--- a/transform.go
+++ b/transform.go
@@ -35,6 +35,7 @@ var transformFuncs = map[string]bool{
 	"exp":                        true,
 	"floor":                      true,
 	"histogram_avg":              true,
+	"histogram_fraction":         true,
 	"histogram_quantile":         true,
 	"histogram_quantiles":        true,
 	"histogram_share":            true,


### PR DESCRIPTION
fix https://github.com/VictoriaMetrics/VictoriaMetrics/issues/5346

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the histogram_fraction() function in MetricsQL. It is registered as a transform and recognized by the optimizer (arg index 2) so queries using it parse and optimize correctly.

<sup>Written for commit 534f12ac6a590ada7c630cbe9fe0d5a15365eba3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

