### PR TITLE
feat: add support for fill modifiers in binary operations

### DIFF
--- a/binary_op.go
+++ b/binary_op.go
@@ -123,6 +123,16 @@ func isBinaryOpBoolModifier(s string) bool {
 	return s == "bool"
 }
 
+func isBinaryOpFillModifier(s string) bool {
+	s = strings.ToLower(s)
+	switch s {
+	case "fill", "fill_left", "fill_right":
+		return true
+	default:
+		return false
+	}
+}
+
 // IsBinaryOpCmp returns true if op is comparison operator such as '==', '!=', etc.
 func IsBinaryOpCmp(op string) bool {
 	switch op {

--- a/binary_op.go
+++ b/binary_op.go
@@ -73,6 +73,16 @@ func isBinaryOp(op string) bool {
 	return binaryOps[op]
 }
 
+func isSetOperator(op string) bool {
+	op = strings.ToLower(op)
+	switch op {
+	case "and", "or", "unless", "if", "ifnot", "default":
+		return true
+	default:
+		return false
+	}
+}
+
 func binaryOpPriority(op string) int {
 	op = strings.ToLower(op)
 	return binaryOpPriorities[op]

--- a/optimizer.go
+++ b/optimizer.go
@@ -39,6 +39,9 @@ func canOptimize(e Expr) bool {
 			}
 		}
 	case *BinaryOpExpr:
+		if t.FillLeft != nil && t.FillRight != nil {
+			return canOptimize(t.Left) || canOptimize(t.Right)
+		}
 		return true
 	}
 	return false
@@ -66,8 +69,23 @@ func optimizeInplace(e Expr) {
 	case *BinaryOpExpr:
 		optimizeInplace(t.Left)
 		optimizeInplace(t.Right)
-		lfs := getCommonLabelFilters(t)
-		pushdownBinaryOpFiltersInplace(lfs, t)
+		switch {
+		case t.FillLeft != nil && t.FillRight != nil:
+			// for two-sided fill, no cross-side pushdown.
+		case t.FillLeft != nil:
+			// for fill_left(), only propagate filters from right to left.
+			lfs := getCommonLabelFilters(t.Right)
+			lfs = TrimFiltersByGroupModifier(lfs, t)
+			pushdownBinaryOpFiltersInplace(lfs, t.Left)
+		case t.FillRight != nil:
+			// for fill_right(), only propagate filters from left to right.
+			lfs := getCommonLabelFilters(t.Left)
+			lfs = TrimFiltersByGroupModifier(lfs, t)
+			pushdownBinaryOpFiltersInplace(lfs, t.Right)
+		default:
+			lfs := getCommonLabelFilters(t)
+			pushdownBinaryOpFiltersInplace(lfs, t)
+		}
 	}
 }
 

--- a/optimizer_test.go
+++ b/optimizer_test.go
@@ -192,6 +192,17 @@ func TestOptimize(t *testing.T) {
 	f(`a + on(x) group_right(*) prefix "foo_" b{x="a"}`, `a{x="a"} + on(x) group_right(*) prefix "foo_" b{x="a"}`)
 	f(`a{x="a"} + on(x) group_right(*) prefix "foo_" prefix`, `a{x="a"} + on(x) group_right(*) prefix "foo_" (prefix{x="a"})`)
 	f(`foo{a="a"} ifnot foo{b="b"}`, `foo{a="a"} ifnot foo{a="a",b="b"}`)
+	// with fill modifiers
+	f(`foo + bar{a="b"}`, `foo{a="b"} + bar{a="b"}`)
+	f(`foo + fill(0) bar{a="b"}`, `foo + fill(0) bar{a="b"}`)
+	f(`foo + fill_left(0) bar{a="b"}`, `foo{a="b"} + fill_left(0) bar{a="b"}`)
+	f(`foo{a="b"} + fill_right(0) bar`, `foo{a="b"} + fill_right(0) bar{a="b"}`)
+	f(`foo{x="y"} + fill_left(0) bar{a="b"}`, `foo{a="b",x="y"} + fill_left(0) bar{a="b"}`)
+	f(`foo{x="y"} + fill_right(0) bar{a="b"}`, `foo{x="y"} + fill_right(0) bar{a="b",x="y"}`)
+	f(`foo + fill_left(0) fill_right(1) bar{a="b"}`, `foo + fill_left(0) fill_right(1) bar{a="b"}`)
+	f(`(foo + bar{a="b"}) + fill_left(0) fill_right(1) baz`, `(foo{a="b"} + bar{a="b"}) + fill_left(0) fill_right(1) baz`)
+	f(`foo + fill_left(0) fill_right(1) (bar + baz{a="b"})`, `foo + fill_left(0) fill_right(1) (bar{a="b"} + baz{a="b"})`)
+	f(`foo + fill_left(0) (bar + baz{a="b"})`, `foo{a="b"} + fill_left(0) (bar{a="b"} + baz{a="b"})`)
 
 	// specially handled binary expressions
 	f(`foo{a="b"} or bar{x="y"}`, `foo{a="b"} or bar{x="y"}`)

--- a/parser.go
+++ b/parser.go
@@ -402,6 +402,15 @@ func (p *parser) parseExpr() (Expr, error) {
 				}
 			}
 		}
+		for {
+			ok, err := p.parseFillModifier(&be)
+			if err != nil {
+				return nil, err
+			}
+			if !ok {
+				break
+			}
+		}
 		e2, err := p.parseSingleExpr()
 		if err != nil {
 			return nil, err
@@ -504,6 +513,62 @@ func (p *parser) parseSingleExprWithoutRollupSuffix() (Expr, error) {
 	default:
 		return nil, fmt.Errorf(`singleExpr: unexpected token %q; want "(", "{", "-", "+"`, p.lex.Token)
 	}
+}
+
+func (p *parser) parseFillModifier(be *BinaryOpExpr) (bool, error) {
+	if !isBinaryOpFillModifier(p.lex.Token) {
+		return false, nil
+	}
+	op := strings.ToLower(p.lex.Token)
+	if err := p.lex.Next(); err != nil {
+		return false, err
+	}
+	if p.lex.Token != "(" {
+		p.lex.Prev()
+		return false, nil
+	}
+	if err := p.lex.Next(); err != nil {
+		return false, err
+	}
+	ne, err := p.parseFillValue()
+	if err != nil {
+		return false, fmt.Errorf("cannot parse %s fill value: %w", op, err)
+	}
+	if p.lex.Token != ")" {
+		return false, fmt.Errorf(`%s: unexpected token %q; want ")"`, op, p.lex.Token)
+	}
+	if err := p.lex.Next(); err != nil {
+		return false, err
+	}
+	switch op {
+	case "fill":
+		be.FillLeft = ne
+		be.FillRight = ne
+	case "fill_left":
+		be.FillLeft = ne
+	case "fill_right":
+		be.FillRight = ne
+	}
+	return true, nil
+}
+
+func (p *parser) parseFillValue() (*NumberExpr, error) {
+	neg := false
+	if p.lex.Token == "-" {
+		neg = true
+		if err := p.lex.Next(); err != nil {
+			return nil, err
+		}
+	}
+	ne, err := p.parsePositiveNumberExpr()
+	if err != nil {
+		return nil, err
+	}
+	if neg {
+		ne.N = -ne.N
+		ne.s = "-" + ne.s
+	}
+	return ne, nil
 }
 
 func (p *parser) parsePositiveNumberExpr() (*NumberExpr, error) {
@@ -1896,6 +1961,12 @@ type BinaryOpExpr struct {
 	// If KeepMetricNames is set to true, then the operation should keep metric names.
 	KeepMetricNames bool
 
+	// FillLeft contains the fill value for fill_left() or fill() modifier.
+	FillLeft *NumberExpr
+
+	// FillRight contains the fill value for fill_right() or fill() modifier.
+	FillRight *NumberExpr
+
 	// Left contains left arg for the `left op right` expression.
 	Left Expr
 
@@ -1971,6 +2042,22 @@ func (be *BinaryOpExpr) appendModifiers(dst []byte) []byte {
 			dst = prefix.AppendString(dst)
 		}
 	}
+	if be.FillLeft != nil && be.FillLeft == be.FillRight {
+		dst = append(dst, " fill("...)
+		dst = be.FillLeft.AppendString(dst)
+		dst = append(dst, ')')
+	} else {
+		if be.FillLeft != nil {
+			dst = append(dst, " fill_left("...)
+			dst = be.FillLeft.AppendString(dst)
+			dst = append(dst, ')')
+		}
+		if be.FillRight != nil {
+			dst = append(dst, " fill_right("...)
+			dst = be.FillRight.AppendString(dst)
+			dst = append(dst, ')')
+		}
+	}
 	return dst
 }
 
@@ -1989,7 +2076,7 @@ func needBinaryOpArgParens(arg Expr) bool {
 }
 
 func isReservedBinaryOpIdent(s string) bool {
-	return isBinaryOpGroupModifier(s) || isBinaryOpJoinModifier(s) || isBinaryOpBoolModifier(s) || isPrefixModifier(s)
+	return isBinaryOpGroupModifier(s) || isBinaryOpJoinModifier(s) || isBinaryOpBoolModifier(s) || isPrefixModifier(s) || isBinaryOpFillModifier(s)
 }
 
 func isPrefixModifier(s string) bool {

--- a/parser.go
+++ b/parser.go
@@ -519,6 +519,9 @@ func (p *parser) parseFillModifier(be *BinaryOpExpr) (bool, error) {
 	if !isBinaryOpFillModifier(p.lex.Token) {
 		return false, nil
 	}
+	if isSetOperator(be.Op) {
+		return false, fmt.Errorf(`fill modifier cannot be applied to %q`, be.Op)
+	}
 	op := strings.ToLower(p.lex.Token)
 	if err := p.lex.Next(); err != nil {
 		return false, err

--- a/parser_test.go
+++ b/parser_test.go
@@ -342,6 +342,22 @@ func TestParseSuccess(t *testing.T) {
 	another(`a + oN() gROUp_rigHt(*) PREfix "bar" b`, `a + on() group_right(*) prefix "bar" b`)
 	same(`a + on(a) group_left(x,y) prefix "foo" b`)
 	same(`a + on(a,b) group_right(z) prefix "bar" b`)
+
+	// fill modifiers
+	same(`m * on(job) fill_right(0) n`)
+	same(`m * on(job) fill_left(0) n`)
+	same(`m * on(job) fill_left(0) fill_right(1) n`)
+	same(`m * on(job) fill(0) n`)
+	another(`m * on(job) FILL_RIGHT(0) n`, `m * on(job) fill_right(0) n`)
+	another(`m * on(job) FILL(0) n`, `m * on(job) fill(0) n`)
+	same(`m * on(job) fill_right(-1) n`)
+	same(`m * on(job) fill_left(inf) n`)
+	same(`m * on(job) fill(NaN) n`)
+	same(`m * on(job) group_left() fill_right(0) n`)
+	same(`m * fill_right(0) n`)
+	another(`a + fill_right`, `a + (fill_right)`)
+	another(`a + fill_left`, `a + (fill_left)`)
+	another(`a + fill`, `a + (fill)`)
 	another(`5 - 1 + 3 * 2 ^ 2 ^ 3 - 2  OR Metric {Bar= "Baz", aaa!="bb",cc=~"dd" ,zz !~"ff" } `,
 		`770 or Metric{Bar="Baz",aaa!="bb",cc=~"dd",zz!~"ff"}`)
 

--- a/parser_test.go
+++ b/parser_test.go
@@ -358,6 +358,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`a + fill_right`, `a + (fill_right)`)
 	another(`a + fill_left`, `a + (fill_left)`)
 	another(`a + fill`, `a + (fill)`)
+	another(`m + fill(-1) n + fill(2) w `, `(m + fill(-1) n) + fill(2) w`)
 	another(`5 - 1 + 3 * 2 ^ 2 ^ 3 - 2  OR Metric {Bar= "Baz", aaa!="bb",cc=~"dd" ,zz !~"ff" } `,
 		`770 or Metric{Bar="Baz",aaa!="bb",cc=~"dd",zz!~"ff"}`)
 
@@ -1029,4 +1030,12 @@ func TestParseError(t *testing.T) {
 	f(`with (x={a="b" or c="d"}) x{d="e" or z="c"}`)
 	f(`with (x={a="b" or c="d"}) {x,d="e"}`)
 	f(`with (x={a="b" or c="d"}) {x,d="e" or z="c"}`)
+
+	// invalid fill modifier
+	f(`m + fill on(job) n`)
+	f(`m == fill(0) bool n`)
+	f(`m + fill(0) on(job)  n`)
+	f(`m + on(job) fill(0) group_left() n`)
+	f(`m and fill(0) n`)
+	f(`m + bool group_left m2 fill(0)`)
 }


### PR DESCRIPTION
part of https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10598

<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added support for fill modifiers (fill, fill_left, fill_right) in binary operations to set default values when one side is missing. This expands query syntax and improves control over join behavior.

- **New Features**
  - Parser recognizes fill, fill_left, and fill_right modifiers with numeric values, including negatives, inf, and NaN.
  - fill(x) sets both FillLeft and FillRight; fill_left(x) and fill_right(x) set sides independently.
  - Works alongside existing on()/group_* modifiers and is treated as a reserved identifier.
  - Output formatting includes the fill modifiers via appendModifiers.
  - Added tests for case-insensitive syntax, value parsing, and normalization.

<sup>Written for commit 14411c837f27094f0d1cda206ba2a771d9b937ef. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

