### PR TITLE
Avoid unnecessary parentheses in simple binary expressions

### DIFF
--- a/optimizer_test.go
+++ b/optimizer_test.go
@@ -50,7 +50,7 @@ func TestPushdownBinaryOpFilters(t *testing.T) {
 	f(`foo * ignoring(x) bar`, `{a="b"}`, `foo{a="b"} * ignoring(x) bar{a="b"}`)
 	f(`foo{f1!~"x"} UNLEss bar{f2=~"y.+"}`, `{a="b",x=~"y"}`, `foo{a="b",f1!~"x",x=~"y"} unless bar{a="b",f2=~"y.+",x=~"y"}`)
 	f(`a / sum(x)`, `{a="b",c=~"foo|bar"}`, `a{a="b",c=~"foo|bar"} / sum(x)`)
-	f(`round(rate(x[5m] offset -1h)) + 123 / {a="b"}`, `{x!="y"}`, `round(rate(x{x!="y"}[5m] offset -1h)) + 123 / {a="b",x!="y"}`)
+	f(`round(rate(x[5m] offset -1h)) + 123 / {a="b"}`, `{x!="y"}`, `round(rate(x{x!="y"}[5m] offset -1h)) + (123 / {a="b",x!="y"})`)
 	f(`scalar(foo)+bar`, `{a="b"}`, `scalar(foo) + bar{a="b"}`)
 	f(`vector(foo)`, `{a="b"}`, `vector(foo{a="b"})`)
 	f(`{a="b"} + on() group_left() {c="d"}`, `{a="b"}`, `{a="b"} + on() group_left() {c="d"}`)

--- a/optimizer_test.go
+++ b/optimizer_test.go
@@ -50,7 +50,7 @@ func TestPushdownBinaryOpFilters(t *testing.T) {
 	f(`foo * ignoring(x) bar`, `{a="b"}`, `foo{a="b"} * ignoring(x) bar{a="b"}`)
 	f(`foo{f1!~"x"} UNLEss bar{f2=~"y.+"}`, `{a="b",x=~"y"}`, `foo{a="b",f1!~"x",x=~"y"} unless bar{a="b",f2=~"y.+",x=~"y"}`)
 	f(`a / sum(x)`, `{a="b",c=~"foo|bar"}`, `a{a="b",c=~"foo|bar"} / sum(x)`)
-	f(`round(rate(x[5m] offset -1h)) + 123 / {a="b"}`, `{x!="y"}`, `round(rate(x{x!="y"}[5m] offset -1h)) + (123 / {a="b",x!="y"})`)
+	f(`round(rate(x[5m] offset -1h)) + 123 / {a="b"}`, `{x!="y"}`, `round(rate(x{x!="y"}[5m] offset -1h)) + 123 / {a="b",x!="y"}`)
 	f(`scalar(foo)+bar`, `{a="b"}`, `scalar(foo) + bar{a="b"}`)
 	f(`vector(foo)`, `{a="b"}`, `vector(foo{a="b"})`)
 	f(`{a="b"} + on() group_left() {c="d"}`, `{a="b"}`, `{a="b"} + on() group_left() {c="d"}`)
@@ -382,9 +382,9 @@ func TestOptimize(t *testing.T) {
 	f(`rate(sum(foo[5m:]) by (baz)) + bar{baz="a"}`, `rate(sum(foo{baz="a"}[5m:]) by(baz)) + bar{baz="a"}`)
 
 	// binary ops with constants or scalars
-	f(`100 * foo / bar{baz="a"}`, `(100 * foo{baz="a"}) / bar{baz="a"}`)
-	f(`foo * 100 / bar{baz="a"}`, `(foo{baz="a"} * 100) / bar{baz="a"}`)
-	f(`foo / bar{baz="a"} * 100`, `(foo{baz="a"} / bar{baz="a"}) * 100`)
+	f(`100 * foo / bar{baz="a"}`, `100 * foo{baz="a"} / bar{baz="a"}`)
+	f(`foo * 100 / bar{baz="a"}`, `foo{baz="a"} * 100 / bar{baz="a"}`)
+	f(`foo / bar{baz="a"} * 100`, `foo{baz="a"} / bar{baz="a"} * 100`)
 	f(`scalar(x) * foo / bar{baz="a"}`, `(scalar(x) * foo{baz="a"}) / bar{baz="a"}`)
 	f(`SCALAR(x) * foo / bar{baz="a"}`, `(SCALAR(x) * foo{baz="a"}) / bar{baz="a"}`)
 	f(`100 * on(foo) bar{baz="z"} + a`, `(100 * on(foo) bar{baz="z"}) + a`)

--- a/parser.go
+++ b/parser.go
@@ -1933,11 +1933,11 @@ func (be *BinaryOpExpr) appendStringNoKeepMetricNames(dst []byte) []byte {
 }
 
 func (be *BinaryOpExpr) needLeftParens() bool {
-	return needBinaryOpArgParens(be.Left)
+	return needBinaryOpArgParens(be.Left, be.Op)
 }
 
 func (be *BinaryOpExpr) needRightParens() bool {
-	if needBinaryOpArgParens(be.Right) {
+	if needBinaryOpArgParens(be.Right, be.Op) {
 		return true
 	}
 	switch t := be.Right.(type) {
@@ -1974,15 +1974,44 @@ func (be *BinaryOpExpr) appendModifiers(dst []byte) []byte {
 	return dst
 }
 
-func needBinaryOpArgParens(arg Expr) bool {
+func needBinaryOpArgParens(arg Expr, parentOp string) bool {
 	switch t := arg.(type) {
 	case *BinaryOpExpr:
-		return true
+		// Parens are required when the child op has lower priority than the parent op,
+		// since removing them would change the evaluation order.
+		if binaryOpPriority(t.Op) < binaryOpPriority(parentOp) {
+			return true
+		}
+
+		if parentOp != "+" && parentOp != "-" && parentOp != "*" && parentOp != "/" {
+			return true
+		}
+
+		// Same op: parens are only needed when the sub-expression is not a simple leaf chain.
+		return !isBinaryOpLeafSimple(t)
 	case *RollupExpr:
 		if be, ok := t.Expr.(*BinaryOpExpr); ok && be.KeepMetricNames {
 			return true
 		}
 		return t.Offset != nil || t.At != nil
+	default:
+		return false
+	}
+}
+
+func isBinaryOpLeafSimple(arg Expr) bool {
+	switch t := arg.(type) {
+	case *NumberExpr:
+		return true
+	case *MetricExpr:
+		metricName := t.getMetricName()
+		return !isReservedBinaryOpIdent(metricName)
+	case *BinaryOpExpr:
+		if t.GroupModifier.Op != "" || t.KeepMetricNames || t.JoinModifier.Op != "" {
+			return false
+		}
+
+		return isBinaryOpLeafSimple(t.Left) && isBinaryOpLeafSimple(t.Right)
 	default:
 		return false
 	}

--- a/parser.go
+++ b/parser.go
@@ -1977,13 +1977,9 @@ func (be *BinaryOpExpr) appendModifiers(dst []byte) []byte {
 func needBinaryOpArgParens(arg Expr, parentOp string) bool {
 	switch t := arg.(type) {
 	case *BinaryOpExpr:
-		// Parens are required when the child op has lower priority than the parent op,
-		// since removing them would change the evaluation order.
-		if binaryOpPriority(t.Op) < binaryOpPriority(parentOp) {
-			return true
-		}
-
-		if parentOp != "+" && parentOp != "-" && parentOp != "*" && parentOp != "/" {
+		// Parens are required when the child op priority not equal to parent o one.
+		// For example, a + b / c - d should be a + (b / c) - d.
+		if binaryOpPriority(t.Op) != binaryOpPriority(parentOp) {
 			return true
 		}
 
@@ -2005,6 +2001,8 @@ func isBinaryOpLeafSimple(arg Expr) bool {
 		return true
 	case *MetricExpr:
 		metricName := t.getMetricName()
+		// Parens should be added if metric name equals to a reserved word, such as group_left
+		// For example, a + group_left should become a + (group_left). Otherwise, query won't be parsed.
 		return !isReservedBinaryOpIdent(metricName)
 	case *BinaryOpExpr:
 		if t.GroupModifier.Op != "" || t.KeepMetricNames || t.JoinModifier.Op != "" {

--- a/parser_test.go
+++ b/parser_test.go
@@ -397,8 +397,8 @@ func TestParseSuccess(t *testing.T) {
 	another(`group_left / (sum(1, 2))`, `group_left / sum(1, 2)`)
 
 	// parensExpr
-	another(`(-foo + ((bar) / (baz))) + ((23))`, `((0 - foo) + (bar / baz)) + 23`)
-	another(`(FOO + ((Bar) / (baZ))) + ((23))`, `(FOO + (Bar / baZ)) + 23`)
+	another(`(-foo + ((bar) / (baz))) + ((23))`, `0 - foo + bar / baz + 23`)
+	another(`(FOO + ((Bar) / (baZ))) + ((23))`, `FOO + Bar / baZ + 23`)
 	same(`(foo, bar)`)
 	another(`((foo, bar),(baz))`, `((foo, bar), baz)`)
 	same(`(foo, (bar, baz), ((x, y), (z, y), xx))`)
@@ -479,16 +479,16 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (foo = bar) baz`, `baz`)
 	another(`with (foo = bar) foo + foo{a="b"}`, `bar + bar{a="b"}`)
 	another(`with (foo = bar, bar=baz + f()) test`, `test`)
-	another(`with (ct={job="test"}) a{ct} + ct() + ceil({ct="x"})`, `(a{job="test"} + {job="test"}) + ceil({ct="x"})`)
+	another(`with (ct={job="test"}) a{ct} + ct() + ceil({ct="x"})`, `a{job="test"} + {job="test"} + ceil({ct="x"})`)
 	another(`with (ct={job="test", i="bar"}) ct + {ct, x="d"} + foo{ct, ct} + count(1)`,
-		`(({job="test",i="bar"} + {job="test",i="bar",x="d"}) + foo{job="test",i="bar"}) + count(1)`)
+		`{job="test",i="bar"} + {job="test",i="bar",x="d"} + foo{job="test",i="bar"} + count(1)`)
 	another(`with (foo = bar) {__name__=~"foo"}`, `{__name__=~"foo"}`)
 	another(`with (foo = bar) foo{__name__="foo"}`, `bar`)
 	another(`with (foo = bar) {__name__="foo", x="y"}`, `bar{x="y"}`)
 	another(`with (foo(bar) = {__name__!="bar"}) foo(x)`, `{__name__!="bar"}`)
 	another(`with (foo(bar) = bar{__name__="bar"}) foo(x)`, `x`)
 	another(`with (foo\-bar(baz) = baz + baz) foo\-bar((x,y))`, `(x, y) + (x, y)`)
-	another(`with (foo\-bar(baz) = baz + baz) foo\-bar(x*y)`, `(x * y) + (x * y)`)
+	another(`with (foo\-bar(baz) = baz + baz) foo\-bar(x*y)`, `x * y + x * y`)
 	another(`with (foo\-bar(baz) = baz + baz) foo\-bar(x\*y)`, `x\*y + x\*y`)
 	another(`with (foo\-bar(b\ az) = b\ az + b\ az) foo\-bar(x\*y)`, `x\*y + x\*y`)
 
@@ -521,7 +521,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (ttf = ru(m, n)) ttf`, `(clamp_min(n - clamp_min(m, 0), 0) / clamp_min(n, 0)) * 100`)
 
 	// Verify withExpr recursion and forward reference
-	another(`with (x = x+y, y = x+x) y ^ 2`, `((x + y) + (x + y)) ^ 2`)
+	another(`with (x = x+y, y = x+x) y ^ 2`, `(x + y + x + y) ^ 2`)
 	another(`with (f1(x)=ceil(x), ceil(x)=f1(x)^2) f1(foobar)`, `ceil(foobar)`)
 	another(`with (f1(x)=ceil(x), ceil(x)=f1(x)^2) ceil(foobar)`, `ceil(foobar) ^ 2`)
 
@@ -533,7 +533,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (x(a) = sum(a) by (b)) x(xx) / x(y)`, `sum(xx) by(b) / sum(y) by(b)`)
 	another(`with (f(a,f,x)=clamp(x,f,a)) f(f(x,y,z),1,2)`, `clamp(2, 1, clamp(z, y, x))`)
 	another(`with (f(x)=1+sum(x)) f(foo{bar="baz"})`, `1 + sum(foo{bar="baz"})`)
-	another(`with (a=foo, y=bar, f(a)= a+a+y) f(x)`, `(x + x) + bar`)
+	another(`with (a=foo, y=bar, f(a)= a+a+y) f(x)`, `x + x + bar`)
 	another(`with (f(a, b) = m{a, b}) f({a="x", b="y"}, {c="d"})`, `m{a="x",b="y",c="d"}`)
 	another(`with (xx={a="x"}, f(a, b) = m{a, b}) f({xx, b="y"}, {c="d"})`, `m{a="x",b="y",c="d"}`)
 	another(`with (x() = {b="c"}) foo{x}`, `foo{b="c"}`)
@@ -572,7 +572,7 @@ func TestParseSuccess(t *testing.T) {
 	// Verify nested with exprs
 	another(`with (f(x) = (with(x=y) x) + x) f(z)`, `y + z`)
 	another(`with (x=foo) clamp_min(a, with (y=x) y)`, `clamp_min(a, foo)`)
-	another(`with (x=foo) a * x + (with (y=x) y) / y`, `(a * foo) + (foo / y)`)
+	another(`with (x=foo) a * x + (with (y=x) y) / y`, `a * foo + foo / y`)
 	another(`with (x = with (y = foo) y + x) x/x`, `(foo + x) / (foo + x)`)
 	another(`with (
 		x = {foo="bar"},
@@ -583,7 +583,7 @@ func TestParseSuccess(t *testing.T) {
 			)
 			z(foo) / changes(x)
 	)
-	f(a)`, `(a + (foo * m{foo="bar",y="1"})) / changes(a)`)
+	f(a)`, `(a + foo * m{foo="bar",y="1"}) / changes(a)`)
 
 	// complex withExpr
 	another(`WITH (
@@ -601,7 +601,7 @@ func TestParseSuccess(t *testing.T) {
 		f(x, y) = x2(x) + x*y + x2(y)
 	)
 	f(a, 3)
-	`, `((a ^ 2) + (a * 3)) + 9`)
+	`, `a ^ 2 + a * 3 + 9`)
 	another(`WITH (
 		x2(x) = x^2,
 		f(x, y) = x2(x) + x*y + x2(y)
@@ -633,7 +633,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (rate(a,b)=a+b) rate(1,2)`, `3`)
 	another(`with (now=now(), sum=sum()) x`, `x`)
 	another(`with (rate(a) = b) c`, `c`)
-	another(`rate(x) + with (rate(a,b)=a*b) rate(2,b)`, `rate(x) + (2 * b)`)
+	another(`rate(x) + with (rate(a,b)=a*b) rate(2,b)`, `rate(x) + 2 * b`)
 	another(`with (sum(a,b)=a+b) sum(c,d)`, `c + d`)
 
 	// $__interval and $__rate_interval must be replaced with 1i

--- a/parser_test.go
+++ b/parser_test.go
@@ -397,8 +397,8 @@ func TestParseSuccess(t *testing.T) {
 	another(`group_left / (sum(1, 2))`, `group_left / sum(1, 2)`)
 
 	// parensExpr
-	another(`(-foo + ((bar) / (baz))) + ((23))`, `0 - foo + bar / baz + 23`)
-	another(`(FOO + ((Bar) / (baZ))) + ((23))`, `FOO + Bar / baZ + 23`)
+	another(`(-foo + ((bar) / (baz))) + ((23))`, `0 - foo + (bar / baz) + 23`)
+	another(`(FOO + ((Bar) / (baZ))) + ((23))`, `FOO + (Bar / baZ) + 23`)
 	same(`(foo, bar)`)
 	another(`((foo, bar),(baz))`, `((foo, bar), baz)`)
 	same(`(foo, (bar, baz), ((x, y), (z, y), xx))`)
@@ -488,7 +488,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (foo(bar) = {__name__!="bar"}) foo(x)`, `{__name__!="bar"}`)
 	another(`with (foo(bar) = bar{__name__="bar"}) foo(x)`, `x`)
 	another(`with (foo\-bar(baz) = baz + baz) foo\-bar((x,y))`, `(x, y) + (x, y)`)
-	another(`with (foo\-bar(baz) = baz + baz) foo\-bar(x*y)`, `x * y + x * y`)
+	another(`with (foo\-bar(baz) = baz + baz) foo\-bar(x*y)`, `(x * y) + (x * y)`)
 	another(`with (foo\-bar(baz) = baz + baz) foo\-bar(x\*y)`, `x\*y + x\*y`)
 	another(`with (foo\-bar(b\ az) = b\ az + b\ az) foo\-bar(x\*y)`, `x\*y + x\*y`)
 
@@ -572,7 +572,7 @@ func TestParseSuccess(t *testing.T) {
 	// Verify nested with exprs
 	another(`with (f(x) = (with(x=y) x) + x) f(z)`, `y + z`)
 	another(`with (x=foo) clamp_min(a, with (y=x) y)`, `clamp_min(a, foo)`)
-	another(`with (x=foo) a * x + (with (y=x) y) / y`, `a * foo + foo / y`)
+	another(`with (x=foo) a * x + (with (y=x) y) / y`, `(a * foo) + (foo / y)`)
 	another(`with (x = with (y = foo) y + x) x/x`, `(foo + x) / (foo + x)`)
 	another(`with (
 		x = {foo="bar"},
@@ -583,7 +583,7 @@ func TestParseSuccess(t *testing.T) {
 			)
 			z(foo) / changes(x)
 	)
-	f(a)`, `(a + foo * m{foo="bar",y="1"}) / changes(a)`)
+	f(a)`, `(a + (foo * m{foo="bar",y="1"})) / changes(a)`)
 
 	// complex withExpr
 	another(`WITH (
@@ -601,7 +601,7 @@ func TestParseSuccess(t *testing.T) {
 		f(x, y) = x2(x) + x*y + x2(y)
 	)
 	f(a, 3)
-	`, `a ^ 2 + a * 3 + 9`)
+	`, `(a ^ 2) + (a * 3) + 9`)
 	another(`WITH (
 		x2(x) = x^2,
 		f(x, y) = x2(x) + x*y + x2(y)
@@ -633,7 +633,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (rate(a,b)=a+b) rate(1,2)`, `3`)
 	another(`with (now=now(), sum=sum()) x`, `x`)
 	another(`with (rate(a) = b) c`, `c`)
-	another(`rate(x) + with (rate(a,b)=a*b) rate(2,b)`, `rate(x) + 2 * b`)
+	another(`rate(x) + with (rate(a,b)=a*b) rate(2,b)`, `rate(x) + (2 * b)`)
 	another(`with (sum(a,b)=a+b) sum(c,d)`, `c + d`)
 
 	// $__interval and $__rate_interval must be replaced with 1i

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -258,7 +258,7 @@ x + sum(y)`)
 		`WITH (
   x = a{b="c"} + WITH (q = we{rt="z"}) q,
 )
-abc / x + WITH (rt = 234 + 234) 2 * rt + poasdfklkjlkjfdsfjklfdfdsfdsfddfsfd`)
+(abc / x) + WITH (rt = 234 + 234) (2 * rt) + poasdfklkjlkjfdsfjklfdfdsfdsfddfsfd`)
 
 	// duration replacement in WITH expression
 	another(`WITH(BAR=1m,x(BAZ)=sum(rate({a="b"}[BAR:BAZ])) offset BAR) x`, `WITH (BAR = 1m, x(BAZ) = sum(rate({a="b"}[BAR:BAZ])) offset BAR) x`)
@@ -284,19 +284,44 @@ abc / x + WITH (rt = 234 + 234) 2 * rt + poasdfklkjlkjfdsfjklfdfdsfdsfddfsfd`)
 
 	// see https://github.com/VictoriaMetrics/metricsql/issues/54
 	another(`(1 - (node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes) / node_memory_MemTotal_bytes) * 100`,
-		`(
+		`
+(
   1
     -
   (
-    node_memory_MemFree_bytes + node_memory_Cached_bytes
-      +
-    node_memory_Buffers_bytes
-      +
-    node_memory_SReclaimable_bytes
+    (
+      node_memory_MemFree_bytes + node_memory_Cached_bytes
+        +
+      node_memory_Buffers_bytes
+        +
+      node_memory_SReclaimable_bytes
+    )
+      /
+    node_memory_MemTotal_bytes
   )
-    /
-  node_memory_MemTotal_bytes
 )
   *
 100`)
+
+	`
+(
+  1
+    -
+  (
+    (
+      (
+        (node_memory_MemFree_bytes + node_memory_Cached_bytes)
+          +
+        node_memory_Buffers_bytes
+      )
+        +
+      node_memory_SReclaimable_bytes
+    )
+      /
+    node_memory_MemTotal_bytes
+  )
+)
+  *
+100
+`
 }

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -258,7 +258,7 @@ x + sum(y)`)
 		`WITH (
   x = a{b="c"} + WITH (q = we{rt="z"}) q,
 )
-(abc / x) + WITH (rt = 234 + 234) (2 * rt) + poasdfklkjlkjfdsfjklfdfdsfdsfddfsfd`)
+abc / x + WITH (rt = 234 + 234) 2 * rt + poasdfklkjlkjfdsfjklfdfdsfdsfddfsfd`)
 
 	// duration replacement in WITH expression
 	another(`WITH(BAR=1m,x(BAZ)=sum(rate({a="b"}[BAR:BAZ])) offset BAR) x`, `WITH (BAR = 1m, x(BAZ) = sum(rate({a="b"}[BAR:BAZ])) offset BAR) x`)
@@ -275,4 +275,28 @@ x + sum(y)`)
 	// Verify that exact match __name__ still works
 	another(`{__name__="foo"}`, `foo`)
 	another(`{__name__="foo",bar="baz"}`, `foo{bar="baz"}`)
+
+	same(`1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10`)
+	same(`(1 + 2) * (3 + 4)`)
+	same(`1 + 2 + foo + bar + baz`)
+
+	another(`a offset 5m + b @ start()`, `(a offset 5m) + (b @ start())`)
+
+	// see https://github.com/VictoriaMetrics/metricsql/issues/54
+	another(`(1 - (node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes) / node_memory_MemTotal_bytes) * 100`,
+		`(
+  1
+    -
+  (
+    node_memory_MemFree_bytes + node_memory_Cached_bytes
+      +
+    node_memory_Buffers_bytes
+      +
+    node_memory_SReclaimable_bytes
+  )
+    /
+  node_memory_MemTotal_bytes
+)
+  *
+100`)
 }

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -284,8 +284,7 @@ x + sum(y)`)
 
 	// see https://github.com/VictoriaMetrics/metricsql/issues/54
 	another(`(1 - (node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes) / node_memory_MemTotal_bytes) * 100`,
-		`
-(
+		`(
   1
     -
   (
@@ -302,26 +301,6 @@ x + sum(y)`)
 )
   *
 100`)
-
-	`
-(
-  1
-    -
-  (
-    (
-      (
-        (node_memory_MemFree_bytes + node_memory_Cached_bytes)
-          +
-        node_memory_Buffers_bytes
-      )
-        +
-      node_memory_SReclaimable_bytes
-    )
-      /
-    node_memory_MemTotal_bytes
-  )
-)
-  *
-100
-`
 }
+
+

--- a/utils_example_test.go
+++ b/utils_example_test.go
@@ -24,5 +24,5 @@ func ExampleExpandWithExprs() {
 	fmt.Printf("%s\n", pql)
 
 	// Output:
-	// 100 * (disk_free_bytes{job="$job",instance="$instance"} / disk_total_bytes{job="$job",instance="$instance"})
+	// 100 * disk_free_bytes{job="$job",instance="$instance"} / disk_total_bytes{job="$job",instance="$instance"}
 }


### PR DESCRIPTION
Fixes https://github.com/VictoriaMetrics/metricsql/issues/54

Simple operations include number and metric expressions.

The query like: `1 + 2 + 3`, or `foo + bar + baz` wont be wrapped with parentheses.

The problem with added parentheses that pretify would add a new line, making the query wors,e not better, see example in the issue: https://github.com/VictoriaMetrics/metricsql/issues/54

Example 1:

<img width="1512" height="300" alt="Screenshot 2026-03-18 at 19 04 19" src="https://github.com/user-attachments/assets/15ed6d53-a209-4479-82e3-638be201e00d" />

<img width="1512" height="278" alt="Screenshot 2026-03-18 at 19 04 25" src="https://github.com/user-attachments/assets/6378205d-fda5-4e49-932c-bb0dca8a71f8" />


Example 2: 

<img width="1512" height="242" alt="Screenshot 2026-03-18 at 19 08 51" src="https://github.com/user-attachments/assets/6be01d3a-f854-4f19-88c4-84d8587bfae0" />

<img width="1512" height="554" alt="Screenshot 2026-03-18 at 19 08 56" src="https://github.com/user-attachments/assets/f1e23a0c-aad2-472f-8271-05ac885c8338" />

Example 3:

<img width="1512" height="214" alt="Screenshot 2026-03-18 at 19 09 33" src="https://github.com/user-attachments/assets/1d664b71-9ab6-40e8-a005-c7f4c96a6926" />
<img width="1512" height="806" alt="Screenshot 2026-03-18 at 19 09 37" src="https://github.com/user-attachments/assets/6b4adada-9134-4abc-9831-c97f07a3153a" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop adding parentheses for simple arithmetic chains so prettified and optimized queries stay flat and readable. Parens are still added when operator priorities differ or when the subtree isn’t a plain number/metric chain.

- **Bug Fixes**
  - Update `needBinaryOpArgParens(arg, parentOp)` and add `isBinaryOpLeafSimple`: require parens when op priorities differ or the subtree has modifiers, `KeepMetricNames`, functions/rollups, or reserved idents (e.g. `group_left`); skip for plain number/metric chains with the same op.
  - Tests updated across parser/optimizer/prettifier: chains like `100 * foo / bar` and `1 + 2 + foo + bar + baz` stay flat; `a offset 5m + b @ start()` keeps parens; WITH expansions and examples reflect flatter output; `(1 + 2) * (3 + 4)` unchanged.

<sup>Written for commit fd6061d41e16d5905607b01bb27ebca1e5661df7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



