### PR TITLE
Revert avoid unnecessary parentheses change

### DIFF
--- a/optimizer_test.go
+++ b/optimizer_test.go
@@ -382,9 +382,9 @@ func TestOptimize(t *testing.T) {
 	f(`rate(sum(foo[5m:]) by (baz)) + bar{baz="a"}`, `rate(sum(foo{baz="a"}[5m:]) by(baz)) + bar{baz="a"}`)
 
 	// binary ops with constants or scalars
-	f(`100 * foo / bar{baz="a"}`, `100 * foo{baz="a"} / bar{baz="a"}`)
-	f(`foo * 100 / bar{baz="a"}`, `foo{baz="a"} * 100 / bar{baz="a"}`)
-	f(`foo / bar{baz="a"} * 100`, `foo{baz="a"} / bar{baz="a"} * 100`)
+	f(`100 * foo / bar{baz="a"}`, `(100 * foo{baz="a"}) / bar{baz="a"}`)
+	f(`foo * 100 / bar{baz="a"}`, `(foo{baz="a"} * 100) / bar{baz="a"}`)
+	f(`foo / bar{baz="a"} * 100`, `(foo{baz="a"} / bar{baz="a"}) * 100`)
 	f(`scalar(x) * foo / bar{baz="a"}`, `(scalar(x) * foo{baz="a"}) / bar{baz="a"}`)
 	f(`SCALAR(x) * foo / bar{baz="a"}`, `(SCALAR(x) * foo{baz="a"}) / bar{baz="a"}`)
 	f(`100 * on(foo) bar{baz="z"} + a`, `(100 * on(foo) bar{baz="z"}) + a`)

--- a/parser.go
+++ b/parser.go
@@ -1933,11 +1933,11 @@ func (be *BinaryOpExpr) appendStringNoKeepMetricNames(dst []byte) []byte {
 }
 
 func (be *BinaryOpExpr) needLeftParens() bool {
-	return needBinaryOpArgParens(be.Left, be.Op)
+	return needBinaryOpArgParens(be.Left)
 }
 
 func (be *BinaryOpExpr) needRightParens() bool {
-	if needBinaryOpArgParens(be.Right, be.Op) {
+	if needBinaryOpArgParens(be.Right) {
 		return true
 	}
 	switch t := be.Right.(type) {
@@ -1974,42 +1974,15 @@ func (be *BinaryOpExpr) appendModifiers(dst []byte) []byte {
 	return dst
 }
 
-func needBinaryOpArgParens(arg Expr, parentOp string) bool {
+func needBinaryOpArgParens(arg Expr) bool {
 	switch t := arg.(type) {
 	case *BinaryOpExpr:
-		// Parens are required when the child op priority not equal to parent o one.
-		// For example, a + b / c - d should be a + (b / c) - d.
-		if binaryOpPriority(t.Op) != binaryOpPriority(parentOp) {
-			return true
-		}
-
-		// Same op: parens are only needed when the sub-expression is not a simple leaf chain.
-		return !isBinaryOpLeafSimple(t)
+		return true
 	case *RollupExpr:
 		if be, ok := t.Expr.(*BinaryOpExpr); ok && be.KeepMetricNames {
 			return true
 		}
 		return t.Offset != nil || t.At != nil
-	default:
-		return false
-	}
-}
-
-func isBinaryOpLeafSimple(arg Expr) bool {
-	switch t := arg.(type) {
-	case *NumberExpr:
-		return true
-	case *MetricExpr:
-		metricName := t.getMetricName()
-		// Parens should be added if metric name equals to a reserved word, such as group_left
-		// For example, a + group_left should become a + (group_left). Otherwise, query won't be parsed.
-		return !isReservedBinaryOpIdent(metricName)
-	case *BinaryOpExpr:
-		if t.GroupModifier.Op != "" || t.KeepMetricNames || t.JoinModifier.Op != "" {
-			return false
-		}
-
-		return isBinaryOpLeafSimple(t.Left) && isBinaryOpLeafSimple(t.Right)
 	default:
 		return false
 	}

--- a/parser_test.go
+++ b/parser_test.go
@@ -397,8 +397,8 @@ func TestParseSuccess(t *testing.T) {
 	another(`group_left / (sum(1, 2))`, `group_left / sum(1, 2)`)
 
 	// parensExpr
-	another(`(-foo + ((bar) / (baz))) + ((23))`, `0 - foo + (bar / baz) + 23`)
-	another(`(FOO + ((Bar) / (baZ))) + ((23))`, `FOO + (Bar / baZ) + 23`)
+	another(`(-foo + ((bar) / (baz))) + ((23))`, `((0 - foo) + (bar / baz)) + 23`)
+	another(`(FOO + ((Bar) / (baZ))) + ((23))`, `(FOO + (Bar / baZ)) + 23`)
 	same(`(foo, bar)`)
 	another(`((foo, bar),(baz))`, `((foo, bar), baz)`)
 	same(`(foo, (bar, baz), ((x, y), (z, y), xx))`)
@@ -479,9 +479,9 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (foo = bar) baz`, `baz`)
 	another(`with (foo = bar) foo + foo{a="b"}`, `bar + bar{a="b"}`)
 	another(`with (foo = bar, bar=baz + f()) test`, `test`)
-	another(`with (ct={job="test"}) a{ct} + ct() + ceil({ct="x"})`, `a{job="test"} + {job="test"} + ceil({ct="x"})`)
+	another(`with (ct={job="test"}) a{ct} + ct() + ceil({ct="x"})`, `(a{job="test"} + {job="test"}) + ceil({ct="x"})`)
 	another(`with (ct={job="test", i="bar"}) ct + {ct, x="d"} + foo{ct, ct} + count(1)`,
-		`{job="test",i="bar"} + {job="test",i="bar",x="d"} + foo{job="test",i="bar"} + count(1)`)
+		`(({job="test",i="bar"} + {job="test",i="bar",x="d"}) + foo{job="test",i="bar"}) + count(1)`)
 	another(`with (foo = bar) {__name__=~"foo"}`, `{__name__=~"foo"}`)
 	another(`with (foo = bar) foo{__name__="foo"}`, `bar`)
 	another(`with (foo = bar) {__name__="foo", x="y"}`, `bar{x="y"}`)
@@ -521,7 +521,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (ttf = ru(m, n)) ttf`, `(clamp_min(n - clamp_min(m, 0), 0) / clamp_min(n, 0)) * 100`)
 
 	// Verify withExpr recursion and forward reference
-	another(`with (x = x+y, y = x+x) y ^ 2`, `(x + y + x + y) ^ 2`)
+	another(`with (x = x+y, y = x+x) y ^ 2`, `((x + y) + (x + y)) ^ 2`)
 	another(`with (f1(x)=ceil(x), ceil(x)=f1(x)^2) f1(foobar)`, `ceil(foobar)`)
 	another(`with (f1(x)=ceil(x), ceil(x)=f1(x)^2) ceil(foobar)`, `ceil(foobar) ^ 2`)
 
@@ -533,7 +533,7 @@ func TestParseSuccess(t *testing.T) {
 	another(`with (x(a) = sum(a) by (b)) x(xx) / x(y)`, `sum(xx) by(b) / sum(y) by(b)`)
 	another(`with (f(a,f,x)=clamp(x,f,a)) f(f(x,y,z),1,2)`, `clamp(2, 1, clamp(z, y, x))`)
 	another(`with (f(x)=1+sum(x)) f(foo{bar="baz"})`, `1 + sum(foo{bar="baz"})`)
-	another(`with (a=foo, y=bar, f(a)= a+a+y) f(x)`, `x + x + bar`)
+	another(`with (a=foo, y=bar, f(a)= a+a+y) f(x)`, `(x + x) + bar`)
 	another(`with (f(a, b) = m{a, b}) f({a="x", b="y"}, {c="d"})`, `m{a="x",b="y",c="d"}`)
 	another(`with (xx={a="x"}, f(a, b) = m{a, b}) f({xx, b="y"}, {c="d"})`, `m{a="x",b="y",c="d"}`)
 	another(`with (x() = {b="c"}) foo{x}`, `foo{b="c"}`)
@@ -601,7 +601,7 @@ func TestParseSuccess(t *testing.T) {
 		f(x, y) = x2(x) + x*y + x2(y)
 	)
 	f(a, 3)
-	`, `(a ^ 2) + (a * 3) + 9`)
+	`, `((a ^ 2) + (a * 3)) + 9`)
 	another(`WITH (
 		x2(x) = x^2,
 		f(x, y) = x2(x) + x*y + x2(y)

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -280,4 +280,6 @@ x + sum(y)`)
 	// Verify that exact match __name__ still works
 	another(`{__name__="foo"}`, `foo`)
 	another(`{__name__="foo",bar="baz"}`, `foo{bar="baz"}`)
+
+	another(`10 - (3 + 3 + 4)`, `10 - ((3 + 3) + 4)`)
 }

--- a/prettifier_test.go
+++ b/prettifier_test.go
@@ -280,32 +280,4 @@ x + sum(y)`)
 	// Verify that exact match __name__ still works
 	another(`{__name__="foo"}`, `foo`)
 	another(`{__name__="foo",bar="baz"}`, `foo{bar="baz"}`)
-
-	same(`1 + 2 + 3 + 4 + 5 + 6 + 7 + 8 + 9 + 10`)
-	same(`(1 + 2) * (3 + 4)`)
-	same(`1 + 2 + foo + bar + baz`)
-
-	another(`a offset 5m + b @ start()`, `(a offset 5m) + (b @ start())`)
-
-	// see https://github.com/VictoriaMetrics/metricsql/issues/54
-	another(`(1 - (node_memory_MemFree_bytes + node_memory_Cached_bytes + node_memory_Buffers_bytes + node_memory_SReclaimable_bytes) / node_memory_MemTotal_bytes) * 100`,
-		`(
-  1
-    -
-  (
-    (
-      node_memory_MemFree_bytes + node_memory_Cached_bytes
-        +
-      node_memory_Buffers_bytes
-        +
-      node_memory_SReclaimable_bytes
-    )
-      /
-    node_memory_MemTotal_bytes
-  )
-)
-  *
-100`)
 }
-
-

--- a/utils_example_test.go
+++ b/utils_example_test.go
@@ -24,5 +24,5 @@ func ExampleExpandWithExprs() {
 	fmt.Printf("%s\n", pql)
 
 	// Output:
-	// 100 * disk_free_bytes{job="$job",instance="$instance"} / disk_total_bytes{job="$job",instance="$instance"}
+	// 100 * (disk_free_bytes{job="$job",instance="$instance"} / disk_total_bytes{job="$job",instance="$instance"})
 }


### PR DESCRIPTION
The change introduced in https://github.com/VictoriaMetrics/metricsql/pull/63 breaks query like this:

```
10 - (3 + 3 + 4)
```

which is transformed into:

```
10 - 3 + 3 + 4
```

Those queries produce different results. 

Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/10856

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the optimization that removed parentheses in binary expressions to restore correct evaluation order. Prevents wrong rewrites like 10 - (3 + 3 + 4) → 10 - 3 + 3 + 4 (fixes VictoriaMetrics/VictoriaMetrics#10856).

- **Bug Fixes**
  - Parser now always adds parentheses around binary operands; removed priority-based elision logic.
  - Updated tests and examples to expect preserved grouping (e.g., (a * b) / c and 100 * (x / y)).

<sup>Written for commit 4121a48c1a5f066804e79ed4a2b4564987975e3f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

