### PR TITLE
support range() function

### DIFF
--- a/transform.go
+++ b/transform.go
@@ -74,6 +74,7 @@ var transformFuncs = map[string]bool{
 	"rand":                       true,
 	"rand_exponential":           true,
 	"rand_normal":                true,
+	"range":                      true,
 	"range_avg":                  true,
 	"range_first":                true,
 	"range_last":                 true,


### PR DESCRIPTION
implement https://github.com/VictoriaMetrics/VictoriaMetrics/issues/11028

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for the range() transform function by registering it in the transform function map. Queries using range() are now recognized alongside range_avg, range_first, and range_last.

<sup>Written for commit 17023845ab9d3ec660baf3f7bf9d6d17e90b1c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/VictoriaMetrics/metricsql/pull/73?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

