### PR TITLE
.github: pin github actions to full-length commit SHA

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,17 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5.6.0
         with:
           go-version: stable
         id: go
       - name: Code checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
       - name: Test
         run: |
           go test -v ./... -coverprofile=coverage.txt -covermode=atomic
       - name: Publish coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
         with:
           token: ${{secrets.CODECOV_TOKEN}}
           files: ./coverage.txt


### PR DESCRIPTION
Pin github actions to full-length commit SHA

cc: @arkid15r 