### PR TITLE
.github: add explicit persist-credentials for checkout action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,8 @@ jobs:
         id: go
       - name: Code checkout
         uses: actions/checkout@08eba0b27e820071cde6df949e0beb9ba4906955  # v4.3.0
+        with:
+          persist-credentials: false
       - name: Test
         run: |
           go test -v ./... -coverprofile=coverage.txt -covermode=atomic


### PR DESCRIPTION
Add explicit `persist-credentials` as it's `true` by default.

More Info: https://github.com/actions/checkout/issues/485

cc: @arkid15r