### PR TITLE
lexer: drop unreachable condition in scanSingleDuration

### DIFF
--- a/lexer.go
+++ b/lexer.go
@@ -689,12 +689,11 @@ func scanSingleDuration(s string, canBeNegative bool) int {
 		return -1
 	}
 	if s[i] == '.' {
-		j := i
 		i++
 		for i < len(s) && isDecimalChar(s[i]) {
 			i++
 		}
-		if i == j || i == len(s) {
+		if i == len(s) {
 			return -1
 		}
 	}


### PR DESCRIPTION
Fixes #24.

`i == j` in `scanSingleDuration` can never be true. `j` is set to the index of the dot and `i` is incremented right after, so `i` is at least `j+1` by the time the condition is checked. Removing the condition leaves `j` unused, which the compiler confirms.

The reporter asked whether it should be `j+1` instead. It should not. That would reject a duration with a trailing dot such as `-3.H`, which is valid and covered by `TestDurationSuccess`. A trailing dot is accepted for plain numbers too, for example `234.` in `TestScanPositiveNumberSuccess`.

So the condition is not guarding anything and is dropped. `i == len(s)` still rejects a duration that ends with a dot and has no unit.

No change in behaviour. All existing tests pass.
