### PR TITLE
utils: detect a subquery with an implicit step in IsLikelyInvalid

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -73,6 +73,14 @@ func VisitAll(e Expr, f func(expr Expr)) {
 //	rate(default_rollup(foo[1i:1i]) + default_rollup(bar[1i:1i]))
 //	rate(default_rollup(foo[1i:1i]) > 10)
 //
+// A lookbehind window on something other than a series selector is invalid for the same reason,
+// since it is implicitly converted into a subquery with an `1i` step:
+//
+//	sum(foo)[5m]
+//	(foo + bar)[5m]
+//
+// Write such a subquery explicitly, as `sum(foo)[5m:]` or `sum(foo)[5m:1m]`.
+//
 // See https://docs.victoriametrics.com/victoriametrics/metricsql/#implicit-query-conversions
 //
 // Note that rate(foo) is valid expression, since it returns the expected results most of the time, e.g. rate(foo[1i]).
@@ -80,6 +88,18 @@ func IsLikelyInvalid(e Expr) bool {
 	hasImplicitConversion := false
 	VisitAll(e, func(expr Expr) {
 		if hasImplicitConversion {
+			return
+		}
+		if re, ok := expr.(*RollupExpr); ok {
+			// Prometheus allows the lookbehind window only for series selectors, such as `foo[5m]`.
+			// It requires the explicit `q[d:]` or `q[d:step]` form for everything else,
+			// while MetricsQL accepts `q[d]` there and turns it into a subquery.
+			// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6752
+			if re.Window != nil && !re.ForSubquery() {
+				if _, ok := re.Expr.(*MetricExpr); !ok {
+					hasImplicitConversion = true
+				}
+			}
 			return
 		}
 		fe, ok := expr.(*FuncExpr)

--- a/utils_test.go
+++ b/utils_test.go
@@ -96,11 +96,28 @@ func TestIsLikelyInvalid(t *testing.T) {
 
 	// Explicit subqueries are allowed
 	f(`sum_over_time((up > 0)[5m:1s])`, false)
-	f(`rate(sum(foo)[5m])`, false)
+	f(`sum_over_time((up > 0)[5m:])`, false)
 	f(`rate(sum(foo)[5m:3s])`, false)
+	f(`rate(sum(foo)[5m:])`, false)
 
-	// Implicit step in the subquery is OK
-	f(`sum_over_time((up > 0)[5m])`, false)
+	// A subquery must be explicit, since `q[d]` is allowed only for series selectors in Prometheus.
+	// See https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6752
+	f(`sum_over_time((up > 0)[5m])`, true)
+	f(`rate(sum(foo)[5m])`, true)
+	f(`sum by (job) (foo == bool 0)[24h]`, true)
+	f(`sum(foo)[5m]`, true)
+	f(`(foo + bar)[5m]`, true)
+	f(`1 + sum(foo)[5m]`, true)
+	f(`(foo offset 1h)[5m]`, true)
+
+	// The timestamp carve-out above doesn't cover the lookbehind window of its arg
+	f(`timestamp(sum(foo)[5m])`, true)
+	f(`timestamp(sum(foo)[5m:])`, false)
+
+	// A series selector may keep the bare lookbehind window
+	f(`foo[5m] offset 1h`, false)
+	f(`sum by (job) (foo == bool 0)[24h:]`, false)
+	f(`sum by (job) (foo == bool 0)[24h:1m]`, false)
 
 	// This is OK, since it is supported by Prometheus
 	f(`rate(foo{bar=~"baz"}[5m:1s])`, false)


### PR DESCRIPTION
Fixes https://github.com/VictoriaMetrics/VictoriaMetrics/issues/6752

`-search.disableImplicitConversion` accepts `sum by(k8s_cluster_name) (process_state == bool 0)[24h]`. `IsLikelyInvalid` only inspects `FuncExpr` nodes, so a `RollupExpr` with no rollup function around it is never checked.

The hole is wider than the query in the issue. These pass today too:

```
sum(foo)[5m]
(foo + bar)[5m]
1 + sum(foo)[5m]
(foo offset 1h)[5m]
```

The Prometheus parser (v0.55.1) rejects all of them with "ranges only allowed for vector selectors". It allows a bare lookbehind window only on a series selector, so `foo[5m]` stays valid and `sum(foo)[5m:]` is how the subquery gets written.

This flags a `RollupExpr` whose window is not `ForSubquery()` and whose inner expression is not a `MetricExpr`. `ForSubquery()` is already how `evalRollupFunc` tells the two apart, so `sum(foo)[24h:]` and `sum(foo)[24h:1m]` stay valid.

Two existing assertions flip: `rate(sum(foo)[5m])` and `sum_over_time((up > 0)[5m])`, at `utils_test.go:99` and `:103`. Prometheus rejects both. The second carries a comment saying the implicit step is OK, so that is the call I would like a second opinion on.

The `timestamp` carve-out from #55 narrows too. `timestamp(sum(foo)[5m])` becomes invalid, since the window is now checked on its own node. Prometheus rejects that as well. Tests cover both sides.

This does not close the gap with Prometheus everywhere. Prometheus also rejects `1[5m:]` and `time()[5m:]` as scalars in a subquery, and metricsql accepts those. Separate rule, left alone.

I will bump the vendored metricsql in VictoriaMetrics and add the docs and changelog entries there once this merges.
